### PR TITLE
return back go.mod with fixed module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-xmlfmt/xmlfmt
+
+go 1.18


### PR DESCRIPTION
`go.mod` [breaks](https://github.com/go-xmlfmt/xmlfmt/commit/786e26b1e893cd37ded4528d7ee6f14487addc81) xmlfmt cli because of the wrong module name `xmlfmt`. This PR returns `go.mod` with fixed module name `github.com/go-xmlfmt/xmlfmt`.